### PR TITLE
Fix Linux compilation error in graphics.cpp

### DIFF
--- a/source/system/graphics.cpp
+++ b/source/system/graphics.cpp
@@ -254,7 +254,7 @@ static void prepareCameraConstants(ID<Entity> camera, ID<Entity> directionalLigh
 
 		if (cameraView->type == ProjectionType::Perspective)
 		{
-			cameraConstants.anglePerPixel = calcAnglePerPixel(
+			cameraConstants.anglePerPixel = math::calcAnglePerPixel(
 				cameraView->p.perspective.fieldOfView, scaledFramebufferSize.y);
 		}
 		else


### PR DESCRIPTION
- Use math::calcAnglePerPixel instead of undefined calcAnglePerPixel function
- Resolves 'calcAnglePerPixel was not declared in this scope' compilation error
- Fixes camera constant calculations for perspective projection